### PR TITLE
Feat/get profile

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -5,24 +5,25 @@ import { LoginDto } from './dto/login.dto';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { GetUser } from '../common/decorators/get-user.decorator';
 import { User } from '@prisma/client';
+import { UserResponse } from './interfaces/auth-response.interace';
 
 @Controller('api/users')
 export class AuthController {
   constructor(private authService: AuthService) {}
 
   @Post()
-  async register(@Body('user') registerDto: RegisterDto) {
+  async register(@Body('user') registerDto: RegisterDto): Promise<UserResponse> {
     return this.authService.register(registerDto);
   }
 
   @Post('login')
-  async login(@Body('user') loginDto: LoginDto) {
+  async login(@Body('user') loginDto: LoginDto): Promise<UserResponse> {
     return this.authService.login(loginDto);
   }
 
   @UseGuards(JwtAuthGuard)
   @Get('profile')
-  async getProfile(@GetUser() user: User) {
+  async getProfile(@GetUser() user: User): Promise<User> {
     return user; 
   }
 }

--- a/src/profiles/profiles.controller.ts
+++ b/src/profiles/profiles.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Param, Req, UseGuards } from '@nestjs/common';
+import { ProfilesService } from './profiles.service';
+import { AuthGuard } from '@nestjs/passport';
+
+@Controller('api/profiles')
+export class ProfilesController {
+  constructor(private readonly profilesService: ProfilesService) {}
+
+  @Get(':username')
+  async getProfile(@Param('username') userId: number, @Req() req) {
+    const currentUserId = req.user?.id;
+    return this.profilesService.getProfile(currentUserId);
+  }
+}

--- a/src/profiles/profiles.module.ts
+++ b/src/profiles/profiles.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ProfilesController } from './profiles.controller';
+import { ProfilesService } from './profiles.service';
+import { ProfilesRepository } from './profiles.repository';
+import { PrismaService } from '../prisma.service';
+
+@Module({
+  controllers: [ProfilesController],
+  providers: [ProfilesService, ProfilesRepository, PrismaService],
+})
+export class ProfilesModule {}

--- a/src/profiles/profiles.repository.ts
+++ b/src/profiles/profiles.repository.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { User } from '@prisma/client';
+
+@Injectable()
+export class ProfilesRepository {
+  constructor(private prisma: PrismaService) {}
+
+  async findById(userId: number): Promise<User | null> {
+      return this.prisma.User.findUnique({
+        where: { id: userId },
+      });
+  }
+}

--- a/src/profiles/profiles.service.ts
+++ b/src/profiles/profiles.service.ts
@@ -1,0 +1,24 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { ProfilesRepository } from './profiles.repository';
+
+@Injectable()
+export class ProfilesService {
+  constructor(private profilesRepository: ProfilesRepository) {}
+
+  async getProfile(userId: number, currentUserId?: number) {
+    const profile = await this.profilesRepository.findById(userId);
+
+    if (!profile) {
+      throw new NotFoundException('Profile not found');
+    }
+
+    const following = false;
+
+    return {
+      profile: {
+        ...profile,
+        following,
+      },
+    };
+  }
+}


### PR DESCRIPTION
PR này thực hiện chức năng lấy thông tin hồ sơ người dùng (Profile) dựa trên userId.
Chức năng này không yêu cầu xác thực bắt buộc, nhưng nếu người dùng đã đăng nhập thì có thể sử dụng để xác định quan hệ following trong tương lai.
Thêm mới ProfilesModule, ProfilesController, ProfilesService, ProfilesRepository.
Hoàn thiện endpoint:
- GET /api/profiles/:username → Lấy thông tin Profile (authentication optional).
- Profile được lấy từ bảng User (các field username, bio, image).
- Thêm trường following mặc định (false) – sau này sẽ cập nhật logic Follow.